### PR TITLE
Csp strict mode

### DIFF
--- a/Form/ShippingAddress/PostcodeFormModifier.php
+++ b/Form/ShippingAddress/PostcodeFormModifier.php
@@ -45,7 +45,8 @@ class PostcodeFormModifier implements EntityFormModifierInterface
             return;
         }
 
-        $postcode->setAttribute('@change', '$dispatch(\'hyva.checkout.postcode-changed\', $event.target.value)');
+        // Add a CSP-friendly data attribute as a marker
+        $postcode->setAttribute('data-postcode-dispatch', 'true');
     }
 
     public function addPostcodeValidator(EntityFormInterface $form)

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "N/A",
   "type": "magento2-module",
   "require": {
-      "hyva-themes/magento2-hyva-checkout": "^1.1",
+      "hyva-themes/magento2-hyva-checkout": "^1.3",
       "magento/framework": "^102.0 || ^103.0",
       "magento/module-directory": "^100.0"
   },

--- a/view/frontend/templates/checkout/postcode-ajax-validator.phtml
+++ b/view/frontend/templates/checkout/postcode-ajax-validator.phtml
@@ -1,6 +1,9 @@
 <?php declare(strict_types=1);
 
 use Magento\Framework\View\Element\Template;
+use Hyva\Theme\ViewModel\HyvaCsp;
+
+/** @var HyvaCsp $hyvaCsp */
 
 /** @var Template $block */
 $url = $block->getUrl('yireo_postcode_validator/ajax/postcode/');
@@ -50,6 +53,25 @@ $spinner = str_replace("\n", '', $spinner);
             });
         }
     })();
+
+    document.addEventListener('DOMContentLoaded', () => {
+        // Find all elements marked with the data attribute
+        const postcodeElements = document.querySelectorAll('[data-postcode-dispatch="true"]');
+
+        postcodeElements.forEach((postcodeElement) => {
+            postcodeElement.addEventListener('change', (event) => {
+                const value = event.target.value;
+
+                // Dispatch the custom event for postcode change
+                const postcodeChangedEvent = new CustomEvent('hyva.checkout.postcode-changed', {
+                    detail: { value: value },
+                });
+
+                document.dispatchEvent(postcodeChangedEvent);
+            });
+        });
+    });
+
 
     document.addEventListener('hyva.checkout.postcode-changed', function (event) {
         //console.log('hyva.checkout.postcode-changed', Alpine.data('shipping').state);
@@ -143,3 +165,4 @@ $spinner = str_replace("\n", '', $spinner);
         }
     });
 </script>
+<?php $hyvaCsp->registerInlineScript(); ?>


### PR DESCRIPTION
I was playing with the new Hyvä checkout, and using this module. I ran into an issue that the validation in the browser was causing an error in strict mode. This fixed it. Maybe it's useful?